### PR TITLE
Disable r8125 driver on bpi-r1

### DIFF
--- a/config-bpi-r1
+++ b/config-bpi-r1
@@ -56,4 +56,5 @@ CONFIG_PACKAGE_kmod-ledtrig-pattern=y
 CONFIG_PACKAGE_kmod-ledtrig-audio=y
 CONFIG_PACKAGE_kmod-ipt-led=y
 CONFIG_PACKAGE_kmod-usb-ledtrig-usbport=y
+# CONFIG_PACKAGE_kmod-r8125 is not set
 CONFIG_KERNEL_ARM_MODULE_PLTS=y


### PR DESCRIPTION
Thanks for your contribution to OpenMPTCProuter!

You need to follow contributing rules.

Please remove this message before posting the pull request.
